### PR TITLE
use parameter description if set

### DIFF
--- a/src/openapi2excel/Builders/WorksheetPartsBuilders/Common/OpenApiSchemaDescriptor.cs
+++ b/src/openapi2excel/Builders/WorksheetPartsBuilders/Common/OpenApiSchemaDescriptor.cs
@@ -31,7 +31,7 @@ internal class OpenApiSchemaDescriptor(IXLWorksheet worksheet, OpenApiDocumentat
       return cell.GetColumnNumber();
    }
 
-   public int AddSchemaDescriptionValues(OpenApiSchema schema, bool required, RowPointer actualRow, int startColumn, bool includeArrayItemType = false)
+   public int AddSchemaDescriptionValues(OpenApiSchema schema, bool required, RowPointer actualRow, int startColumn, string? description = null, bool includeArrayItemType = false )
    {
       if (schema.Items != null && includeArrayItemType)
       {
@@ -47,7 +47,7 @@ internal class OpenApiSchemaDescriptor(IXLWorksheet worksheet, OpenApiDocumentat
             .CellRight().SetText(schema.Items.GetEnumDescription())
             .CellRight().SetText(options.Language.Get(schema.Deprecated)).SetHorizontalAlignment(XLAlignmentHorizontalValues.Center)
             .CellRight().SetText(schema.GetExampleDescription())
-            .CellRight().SetText(schema.Description.StripHtmlTags());
+            .CellRight().SetText((string.IsNullOrEmpty(schema.Description) ? description : schema.Description).StripHtmlTags());
 
          return cell.GetColumnNumber();
       }
@@ -65,9 +65,9 @@ internal class OpenApiSchemaDescriptor(IXLWorksheet worksheet, OpenApiDocumentat
             .CellRight().SetText(options.Language.Get(schema.Deprecated)).SetHorizontalAlignment(XLAlignmentHorizontalValues.Center)
             .CellRight().SetText(schema.GetDefaultDescription())
             .CellRight().SetText(schema.GetExampleDescription())
-            .CellRight().SetText(schema.Description.StripHtmlTags());
+            .CellRight().SetText((string.IsNullOrEmpty(schema.Description) ? description : schema.Description).StripHtmlTags());
 
-         return cell.GetColumnNumber();
+            return cell.GetColumnNumber();
       }
    }
 }

--- a/src/openapi2excel/Builders/WorksheetPartsBuilders/RequestParametersBuilder.cs
+++ b/src/openapi2excel/Builders/WorksheetPartsBuilders/RequestParametersBuilder.cs
@@ -52,7 +52,7 @@ internal class RequestParametersBuilder(
          .CellRight().SetText(parameter.Style?.ToString())
          .CellRight();
 
-      _schemaDescriptor.AddSchemaDescriptionValues(parameter.Schema, parameter.Required, ActualRow, nextCell.Address.ColumnNumber, true);
+      _schemaDescriptor.AddSchemaDescriptionValues(parameter.Schema, parameter.Required, ActualRow, nextCell.Address.ColumnNumber, parameter.Description, true );
       ActualRow.MoveNext();
    }
 }


### PR DESCRIPTION
this should add parameter description if openapimodel is something like this:

[..]
  "/api/Integration/CreateProduct/{lineCode}": {
            "post": {
                "tags": [
                    "Integration"
                ],
                "summary": "Create a new product in line\r\nNB: the barcode must be unique and not conflicting with line MH01",
                "operationId": "Integration_CreateProduct",
                "parameters": [
                    {
                        "name": "lineCode",
                        "in": "path",
                        **"description": "line code",**
                        "required": true,
                        "schema": {
                            "type": "string"
                        }
                    }
                ],
                "requestBody": {
                    "description": "",
                    "content": {
                        "application/json": {
                            "schema": {
                                "$ref": "#/components/schemas/CreateProductRequest"
                            }
                        }
                    },
                    "required": true
                },
                "responses": {
                    "200": {
                        "description": "OK",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "$ref": "#/components/schemas/EmptyResponse"
                                }
                            }
                        }
                    }
                }
            }
        }
[..]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced schema description handling in OpenAPI to Excel conversion
	- Added support for optional parameter descriptions during Excel worksheet generation

- **Improvements**
	- Updated method signatures to accommodate more flexible description input
	- Improved parameter processing logic for more comprehensive documentation export

<!-- end of auto-generated comment: release notes by coderabbit.ai -->